### PR TITLE
Implement LivePreviewProcessor, link will now be shown in LivePreview

### DIFF
--- a/src/cm6-widget/MarkPlugin.ts
+++ b/src/cm6-widget/MarkPlugin.ts
@@ -31,7 +31,7 @@ export class MarkPlugin {
     update(_update: ViewUpdate) {
         const widgets = this.links.map((x) =>
             Decoration.widget({
-                widget: new MarkWidget(x.letter),
+                widget: new MarkWidget(x.letter, x.type),
                 side: 1,
             }).range(x.index)
         );

--- a/src/cm6-widget/MarkWidget.ts
+++ b/src/cm6-widget/MarkWidget.ts
@@ -1,7 +1,7 @@
 import {WidgetType} from "@codemirror/view";
 
 export class MarkWidget extends WidgetType {
-    constructor(readonly mark: string) {
+    constructor(readonly mark: string, readonly type: string) {
         super();
     }
 
@@ -17,6 +17,7 @@ export class MarkWidget extends WidgetType {
         wrapper.style.display = "inline-block";
         wrapper.style.position = "absolute";
         wrapper.classList.add('jl');
+        wrapper.classList.add('jl-' + this.type);
         wrapper.classList.add('popover');
         wrapper.append(mark);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import {App, MarkdownView, Plugin, PluginSettingTab, Setting, View} from 'obsidian';
+import {App, MarkdownView, Plugin, PluginSettingTab, Setting, View, editorLivePreviewField} from 'obsidian';
 import {Editor} from 'codemirror';
 import {EditorSelection} from "@codemirror/state";
 import {EditorView, ViewPlugin} from "@codemirror/view";
@@ -110,15 +110,14 @@ export default class JumpToLink extends Plugin {
     getMode(currentView: View): VIEW_MODE {
         // @ts-ignore
         const isLegacy = this.app.vault.getConfig("legacyEditor")
-        const isLivePreview = !!currentView.containerEl.querySelector('.is-live-preview')
 
         if (currentView.getState().mode === 'preview') {
             return VIEW_MODE.PREVIEW;
         } else if (isLegacy) {
             return VIEW_MODE.LEGACY;
-        } else if (currentView.getState().mode === 'source' && isLivePreview) {
-            return VIEW_MODE.LIVE_PREVIEW;
         } else if (currentView.getState().mode === 'source') {
+            const isLivePreview = (<{ editor?: { cm: EditorView } }>currentView).editor.cm.state.field(editorLivePreviewField)
+            if(isLivePreview) return VIEW_MODE.LIVE_PREVIEW
             return VIEW_MODE.SOURCE;
         }
 

--- a/src/processors/LivePreviewLinkProcessor.ts
+++ b/src/processors/LivePreviewLinkProcessor.ts
@@ -1,0 +1,52 @@
+import {PreviewLinkHint, SourceLinkHint} from "../../types";
+import {EditorView} from "@codemirror/view";
+import {displayPreviewPopovers, getPreviewLinkHints} from "../utils/preview";
+
+import {getLinkHintLetters, getMDHintLinks} from "../utils/common";
+
+export default class LivePreviewLinkProcessor {
+    view: HTMLElement;
+    cmEditor: EditorView;
+    alphabet: string;
+
+    constructor(view: HTMLElement, editor: EditorView, alphabet: string) {
+        this.view = view;
+        this.cmEditor = editor
+        this.alphabet = alphabet;
+    }
+
+    public init(): [PreviewLinkHint[],SourceLinkHint[]] {
+        const { view, alphabet } = this
+        const links = getPreviewLinkHints(view, alphabet);
+        const sourceLinks = this.getSourceLinkHints();
+        const linkHintLetters = getLinkHintLetters(alphabet, links.length + sourceLinks.length);
+        const sourceLinksRemapped = sourceLinks.map((link, idx) => ({...link, letter: linkHintLetters[idx + links.length]}))
+        displayPreviewPopovers(view, links);
+        return [links, sourceLinksRemapped];
+    }
+
+    public getVisibleLines() {
+        const { cmEditor } = this;
+        let { from, to } = cmEditor.viewport;
+
+        // For CM6 get real visible lines top
+        // @ts-ignore
+        if (cmEditor.viewState?.pixelViewport?.top) {
+            // @ts-ignore
+            const pixelOffsetTop = cmEditor.viewState.pixelViewport.top
+            // @ts-ignore
+            const lines = cmEditor.viewState.viewportLines
+            // @ts-ignore
+            from = lines.filter(line => line.top > pixelOffsetTop)[0]?.from
+        }
+        const content = cmEditor.state.sliceDoc(from, to);
+        return { index: from, content };
+    }
+
+    private getSourceLinkHints = (): SourceLinkHint[] => {
+        const { alphabet } = this;
+        const { index, content } = this.getVisibleLines();
+
+        return getMDHintLinks(content, index, alphabet);
+    }
+}

--- a/src/processors/LivePreviewLinkProcessor.ts
+++ b/src/processors/LivePreviewLinkProcessor.ts
@@ -15,14 +15,14 @@ export default class LivePreviewLinkProcessor {
         this.alphabet = alphabet;
     }
 
-    public init(): [PreviewLinkHint[],SourceLinkHint[]] {
+    public init(): [PreviewLinkHint[],SourceLinkHint[],HTMLElement[]] {
         const { view, alphabet } = this
         const links = getPreviewLinkHints(view, alphabet);
         const sourceLinks = this.getSourceLinkHints();
         const linkHintLetters = getLinkHintLetters(alphabet, links.length + sourceLinks.length);
         const sourceLinksRemapped = sourceLinks.map((link, idx) => ({...link, letter: linkHintLetters[idx + links.length]}))
-        displayPreviewPopovers(links);
-        return [links, sourceLinksRemapped];
+        const linkHintHtmlElements = displayPreviewPopovers(links);
+        return [links, sourceLinksRemapped, linkHintHtmlElements];
     }
 
     public getVisibleLines() {

--- a/src/processors/LivePreviewLinkProcessor.ts
+++ b/src/processors/LivePreviewLinkProcessor.ts
@@ -21,7 +21,7 @@ export default class LivePreviewLinkProcessor {
         const sourceLinks = this.getSourceLinkHints();
         const linkHintLetters = getLinkHintLetters(alphabet, links.length + sourceLinks.length);
         const sourceLinksRemapped = sourceLinks.map((link, idx) => ({...link, letter: linkHintLetters[idx + links.length]}))
-        displayPreviewPopovers(view, links);
+        displayPreviewPopovers(view.querySelector('div.cm-scroller'), links);
         return [links, sourceLinksRemapped];
     }
 

--- a/src/processors/LivePreviewLinkProcessor.ts
+++ b/src/processors/LivePreviewLinkProcessor.ts
@@ -21,7 +21,7 @@ export default class LivePreviewLinkProcessor {
         const sourceLinks = this.getSourceLinkHints();
         const linkHintLetters = getLinkHintLetters(alphabet, links.length + sourceLinks.length);
         const sourceLinksRemapped = sourceLinks.map((link, idx) => ({...link, letter: linkHintLetters[idx + links.length]}))
-        displayPreviewPopovers(view.querySelector('div.cm-scroller'), links);
+        displayPreviewPopovers(links);
         return [links, sourceLinksRemapped];
     }
 

--- a/src/processors/PreviewLinkProcessor.ts
+++ b/src/processors/PreviewLinkProcessor.ts
@@ -13,7 +13,7 @@ export default class PreviewLinkProcessor {
     public init(): PreviewLinkHint[] {
         const { view, alphabet } = this
         const links = getPreviewLinkHints(view, alphabet);
-        displayPreviewPopovers(view, links);
+        displayPreviewPopovers(links);
         return links;
     }
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -58,9 +58,9 @@ export function getMDHintLinks(content: string, offset: number, letters: string)
     // expecting either [[Link]] or [[Link|Title]]
     const regExInternal = /\[\[(.+?)(\|.+?)?]]/g;
     // expecting [Title](../example.md)
-    const regExMdInternal = /\[[^\[\]]+?\]\((.+?:\/\/.+?)\)/g;
+    const regExMdInternal = /\[.+?]\(((\.\.|\w|\d).+?)\)/g;
     // expecting [Title](file://link), [Title](https://link) or any other [Jira-123](jira://bla-bla) link
-    const regExExternal = /\[.+?]\((.+?:\/\/.+?)\)/g;
+    const regExExternal = /\[[^\[\]]+?\]\((.+?:\/\/.+?)\)/g;
     // expecting http://hogehoge or https://hogehoge
     const regExUrl = /( |\n|^)(https?:\/\/[^ \n]+)/g;
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -58,7 +58,7 @@ export function getMDHintLinks(content: string, offset: number, letters: string)
     // expecting either [[Link]] or [[Link|Title]]
     const regExInternal = /\[\[(.+?)(\|.+?)?]]/g;
     // expecting [Title](../example.md)
-    const regExMdInternal = /\[.+?]\(((\.\.|\w|\d).+?)\)/g;
+    const regExMdInternal = /\[[^\[\]]+?\]\(((\.\.|\w|\d).+?)\)/g;
     // expecting [Title](file://link), [Title](https://link) or any other [Jira-123](jira://bla-bla) link
     const regExExternal = /\[[^\[\]]+?\]\((.+?:\/\/.+?)\)/g;
     // expecting http://hogehoge or https://hogehoge

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -58,33 +58,42 @@ export function getMDHintLinks(content: string, offset: number, letters: string)
     // expecting either [[Link]] or [[Link|Title]]
     const regExInternal = /\[\[(.+?)(\|.+?)?]]/g;
     // expecting [Title](../example.md)
-    const regExMdInternal = /\[.+?]\(((\.\.|\w|\d).+?)\)/g;
+    const regExMdInternal = /\[[^\[\]]+?\]\((.+?:\/\/.+?)\)/g;
     // expecting [Title](file://link), [Title](https://link) or any other [Jira-123](jira://bla-bla) link
     const regExExternal = /\[.+?]\((.+?:\/\/.+?)\)/g;
     // expecting http://hogehoge or https://hogehoge
     const regExUrl = /( |\n|^)(https?:\/\/[^ \n]+)/g;
 
-    let linksWithIndex: { index: number, type: 'internal' | 'external', linkText: string }[] = [];
+    type IndexedLink = { index: number, type: 'internal' | 'external', linkText: string }
+    let indexes = new Set<number>()
+    let linksWithIndex: IndexedLink[] = [];
     let regExResult;
+
+    const addLinkToArray = (link: IndexedLink) => {
+        if(indexes.has(link.index)) return
+        indexes.add(link.index)
+        linksWithIndex.push(link)
+    }
 
     while(regExResult = regExInternal.exec(content)) {
         const linkText = regExResult[1]?.trim();
-        linksWithIndex.push({ index: regExResult.index + offset, type: 'internal', linkText });
+        addLinkToArray({ index: regExResult.index + offset, type: 'internal', linkText });
+    }
+
+    // External Link above internal, to prefer type external over interal in case of a dupe
+    while(regExResult = regExExternal.exec(content)) {
+        const linkText = regExResult[1];
+        addLinkToArray({ index: regExResult.index + offset, type: 'external', linkText })
     }
 
     while(regExResult = regExMdInternal.exec(content)) {
         const linkText = regExResult[1];
-        linksWithIndex.push({ index: regExResult.index + offset, type: 'internal', linkText });
-    }
-
-    while(regExResult = regExExternal.exec(content)) {
-        const linkText = regExResult[1];
-        linksWithIndex.push({ index: regExResult.index + offset, type: 'external', linkText })
+        addLinkToArray({ index: regExResult.index + offset, type: 'internal', linkText });
     }
 
     while(regExResult = regExUrl.exec(content)) {
         const linkText = regExResult[2];
-        linksWithIndex.push({ index: regExResult.index + offset + 1, type: 'external', linkText })
+        addLinkToArray({ index: regExResult.index + offset + 1, type: 'external', linkText })
     }
 
     const linkHintLetters = getLinkHintLetters(letters, linksWithIndex.length);
@@ -99,9 +108,10 @@ export function getMDHintLinks(content: string, offset: number, letters: string)
     return linksWithLetter.filter(link => link.letter);
 }
 
-export function createWidgetElement(content: string) {
+export function createWidgetElement(content: string, type: string) {
     const linkHintEl = activeDocument.createElement('div');
     linkHintEl.classList.add('jl');
+    linkHintEl.classList.add('jl-'+type);
     linkHintEl.classList.add('popover');
     linkHintEl.innerHTML = content;
     return linkHintEl;
@@ -111,7 +121,7 @@ export function displaySourcePopovers(cmEditor: Editor, linkKeyMap: SourceLinkHi
     const drawWidget = (cmEditor: Editor, linkHint: SourceLinkHint) => {
         const pos = cmEditor.posFromIndex(linkHint.index);
         // the fourth parameter is undocumented. it specifies where the widget should be place
-        return (cmEditor as any).addWidget(pos, createWidgetElement(linkHint.letter), false, 'over');
+        return (cmEditor as any).addWidget(pos, createWidgetElement(linkHint.letter, linkHint.type), false, 'over');
     }
 
     linkKeyMap.forEach(x => drawWidget(cmEditor, x));

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -4,7 +4,7 @@ import {getLinkHintLetters} from "./common";
 export function getPreviewLinkHints(previewViewEl: HTMLElement, letters: string ): PreviewLinkHint[] {
     const anchorEls = previewViewEl.querySelectorAll('a');
     const embedEls = previewViewEl.querySelectorAll('.internal-embed');
-
+    
     const linkHints: PreviewLinkHint[] = [];
     anchorEls.forEach((anchorEl, _i) => {
         if (checkIsPreviewElOnScreen(previewViewEl, anchorEl)) {
@@ -16,7 +16,7 @@ export function getPreviewLinkHints(previewViewEl: HTMLElement, letters: string 
             : 'external';
 
         const linkText = linkType === 'internal'
-            ? anchorEl.dataset['href']
+            ? anchorEl.dataset['href'] ?? anchorEl.href
             : anchorEl.href;
 
         let offsetParent = anchorEl.offsetParent as HTMLElement;
@@ -32,7 +32,6 @@ export function getPreviewLinkHints(previewViewEl: HTMLElement, letters: string 
                 offsetParent = offsetParent.offsetParent as HTMLElement;
             }
         }
-
         linkHints.push({
             letter: '',
             linkText: linkText,
@@ -109,7 +108,7 @@ export function displayPreviewPopovers(markdownPreviewViewEl: HTMLElement, linkH
         const linkHintEl = markdownPreviewViewEl.createEl('div');
         linkHintEl.style.top = linkHint.top + 'px';
         linkHintEl.style.left = linkHint.left + 'px';
-
+        
         linkHintEl.textContent = linkHint.letter;
         linkHintEl.classList.add('jl');
         linkHintEl.classList.add('popover');

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -33,6 +33,7 @@ export function getPreviewLinkHints(previewViewEl: HTMLElement, letters: string 
             }
         }
         linkHints.push({
+            linkElement: anchorEl,
             letter: '',
             linkText: linkText,
             type: linkType,
@@ -65,6 +66,7 @@ export function getPreviewLinkHints(previewViewEl: HTMLElement, letters: string 
             }
 
             linkHints.push({
+                linkElement: linkEl,
                 letter: '',
                 linkText: linkText,
                 type: 'internal',
@@ -103,15 +105,16 @@ export function checkIsPreviewElOnScreen(parent: HTMLElement, el: HTMLElement) {
     return el.offsetTop < parent.scrollTop || el.offsetTop > parent.scrollTop + parent.offsetHeight
 }
 
-export function displayPreviewPopovers(markdownPreviewViewEl: HTMLElement, linkHints: PreviewLinkHint[]): void {
+export function displayPreviewPopovers(linkHints: PreviewLinkHint[]): void {
     for (let linkHint of linkHints) {
-        const linkHintEl = markdownPreviewViewEl.createEl('div');
-        linkHintEl.style.top = linkHint.top + 'px';
-        linkHintEl.style.left = linkHint.left + 'px';
-        
-        linkHintEl.textContent = linkHint.letter;
-        linkHintEl.classList.add('jl');
-        linkHintEl.classList.add('popover');
+        const popoverElement = linkHint.linkElement.createEl('span');
+        linkHint.linkElement.style.position = 'relative'
+        popoverElement.style.top = '0px';
+        popoverElement.style.left = '0px';
+        popoverElement.textContent = linkHint.letter;
+        popoverElement.classList.add('jl');
+        popoverElement.classList.add('jl-'+linkHint.type);
+        popoverElement.classList.add('popover');
     }
 }
 

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -105,7 +105,8 @@ export function checkIsPreviewElOnScreen(parent: HTMLElement, el: HTMLElement) {
     return el.offsetTop < parent.scrollTop || el.offsetTop > parent.scrollTop + parent.offsetHeight
 }
 
-export function displayPreviewPopovers(linkHints: PreviewLinkHint[]): void {
+export function displayPreviewPopovers(linkHints: PreviewLinkHint[]): HTMLElement[] {
+    const linkHintHtmlElements: HTMLElement[] = []
     for (let linkHint of linkHints) {
         const popoverElement = linkHint.linkElement.createEl('span');
         linkHint.linkElement.style.position = 'relative'
@@ -115,6 +116,8 @@ export function displayPreviewPopovers(linkHints: PreviewLinkHint[]): void {
         popoverElement.classList.add('jl');
         popoverElement.classList.add('jl-'+linkHint.type);
         popoverElement.classList.add('popover');
+        linkHintHtmlElements.push(popoverElement)
     }
+    return linkHintHtmlElements
 }
 

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,7 @@ export interface LinkHintBase {
 }
 
 export interface PreviewLinkHint extends LinkHintBase {
+	linkElement: HTMLElement
 	left: number;
 	top: number;
 }


### PR DESCRIPTION
Well, I added support for live preview.

There's a slight issue with the plugin frontmatter-links. It will be detected twice, therefore 2 keys will be shown, but I don't think that should be a big issue...

Here's a screenshot from my test
(The list is generated with dataview)
![image](https://github.com/mrjackphil/obsidian-jump-to-link/assets/16666597/5fd8fe85-ea0f-48c3-88b1-35ff1107ca05)
