### PR TITLE
fix: unreachable letter combinations in live-preview mode

### DIFF
--- a/src/processors/LivePreviewLinkProcessor.ts
+++ b/src/processors/LivePreviewLinkProcessor.ts
@@ -20,9 +20,10 @@ export default class LivePreviewLinkProcessor {
         const links = getPreviewLinkHints(view, alphabet);
         const sourceLinks = this.getSourceLinkHints();
         const linkHintLetters = getLinkHintLetters(alphabet, links.length + sourceLinks.length);
+        const linksRemapped = links.map((link, idx) => ({...link, letter: linkHintLetters[idx]}))
         const sourceLinksRemapped = sourceLinks.map((link, idx) => ({...link, letter: linkHintLetters[idx + links.length]}))
-        const linkHintHtmlElements = displayPreviewPopovers(links);
-        return [links, sourceLinksRemapped, linkHintHtmlElements];
+        const linkHintHtmlElements = displayPreviewPopovers(linksRemapped);
+        return [linksRemapped, sourceLinksRemapped, linkHintHtmlElements];
     }
 
     public getVisibleLines() {

--- a/src/processors/LivePreviewLinkProcessor.ts
+++ b/src/processors/LivePreviewLinkProcessor.ts
@@ -20,8 +20,8 @@ export default class LivePreviewLinkProcessor {
         const links = getPreviewLinkHints(view, alphabet);
         const sourceLinks = this.getSourceLinkHints();
         const linkHintLetters = getLinkHintLetters(alphabet, links.length + sourceLinks.length);
-        const linksRemapped = links.map((link, idx) => ({...link, letter: linkHintLetters[idx]}))
-        const sourceLinksRemapped = sourceLinks.map((link, idx) => ({...link, letter: linkHintLetters[idx + links.length]}))
+        const linksRemapped = links.map((link, idx) => ({...link, letter: linkHintLetters[idx]})).filter(link => link.letter)
+        const sourceLinksRemapped = sourceLinks.map((link, idx) => ({...link, letter: linkHintLetters[idx + links.length]})).filter(link => link.letter)
         const linkHintHtmlElements = displayPreviewPopovers(linksRemapped);
         return [linksRemapped, sourceLinksRemapped, linkHintHtmlElements];
     }


### PR DESCRIPTION
Addresses issue #64. In live preview mode, when there are both markdown and live preview links, the letter combinations to jump to those links will sometimes be unreachable, for example both "a" and "aa" being present.

For an example of how this occurs, we'll assume there are three markdown links and three live preview links, and the characters used for link hints are "abcd":

1. First the three markdown links are found and three letters generated for them: ["a", "b", "c"
2. Next, the three live preview links are found and three letters generated for them: ["a", "b", "c"]
3. To disambiguate these links, we then generate a number of letters equal to the total number of links: ["b", "c", "d", "aa", "ab", "ac"]
4. These last three letters are used to overwrite the live preview links: ["aa", "ab", "ac"]
5. Finally, the markdown and live preview link arrays are combined, resulting in the bugged behaviour: ["a", "b", "c", "aa", "ab", "ac"]

I've fixed the bug by also overwriting the letters for the markdown links with the first three letters generated in step three. A more elegant fix would involve pulling the letter generation functionality out of the three link hint functions (`getPreviewLinkHints`, `getMDLinkHints` and `extractRegexBlocks`) so that the letters can be applied to the links later in a single step.