### PR TITLE
feat: add setting to change the character count for lightspeed jumps

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -233,8 +233,8 @@ export default class JumpToLink extends Plugin {
                 }
             }
 
-            // stop when length of array is equal to 2
-            if (keyArray.length === 2) {
+            // stop when length of array is equal to lightspeedCharacterCount
+            if (keyArray.length === this.settings.lightspeedCharacterCount) {
                 const stringToSearch = this.settings.lightspeedJumpToStartOfWord ? "\\b" + keyArray.join("") : keyArray.join("");
 
                 this.handleJumpToRegex(stringToSearch, this.settings.lightspeedCaseSensitive);
@@ -486,5 +486,23 @@ class SettingTab extends PluginSettingTab {
                     await this.plugin.saveData(this.plugin.settings);
                 });
             });
+
+        new Setting(containerEl)
+            .setName('Number of characters for Lightspeed jump')
+            .setDesc(
+                'Determines how many characters you need to type to perform a Lightspeed jump.'
+            )
+            .addText(
+                (text) =>
+                    (text
+                        .setValue(String(this.plugin.settings.lightspeedCharacterCount))
+                        .onChange(async (value) => {
+                            const num = Number(value);
+                            if (!isNaN(num)) {
+                                this.plugin.settings.lightspeedCharacterCount = num;
+                                await this.plugin.saveData(this.plugin.settings);
+                            }
+                        }).inputEl.type = "number")
+            );
     }
 }

--- a/types.ts
+++ b/types.ts
@@ -23,6 +23,7 @@ export class Settings {
 	lightspeedCaseSensitive: boolean = false;
 	jumpToLinkIfOneLinkOnly: boolean = true;
 	lightspeedJumpToStartOfWord: boolean = true;
+	lightspeedCharacterCount: number = 2;
 }
 
 export class Processor {


### PR DESCRIPTION
To be more inline with how easymotion/vimium work, it would be good to have the ability to jump using a single character. This PR adds a new setting which allows this, while keeping the default to 2 characters.