### PR TITLE
fix: remove duplicate H from suggested link hint chars in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Quickly navigate between links, or jump to any word on the page using hotkeys.
 - Jump to Anywhere works both in regular editor mode, and in VIM mode!
 - Custom RegEx can be configured to user preference
 - Default configuration adds a label on words 3 characters or greater: [Regex: `\b\w{3,}\b`]
-- Suggested `Characters used for link hints` setting for Jump to Anywhere: `asdfghhjklqwertyuiopzxcvbnm`
+- Suggested `Characters used for link hints` setting for Jump to Anywhere: `asdfghjklqwertyuiopzxcvbnm`
   - These settings ensure that all 26 letters are available for jumping in documents with large amounts of text.
   - If there are more matches than available letters, the label will show `undefined` and it will not be possible to jump there.
 


### PR DESCRIPTION
Just a small fix here, the README's suggestion for link hint characters includes a duplicate `h`, which if used, slightly breaks jumping in certain cases.

E.g. the `HERE` below can't be jumped to:

<img width="591" height="217" alt="Screen Shot 2025-08-07 at 9 40 28 AM" src="https://github.com/user-attachments/assets/99efafc9-2c64-4c83-84dd-5664a7bb9df8" />

because pressing `H` jumps to the second `H` (the `here`):

<img width="602" height="246" alt="Screen Shot 2025-08-07 at 9 41 49 AM" src="https://github.com/user-attachments/assets/d1bf6ff3-06ca-4461-801c-8a89163d5538" />

So this PR just removes that duplicate `H` from the README's suggestion.

And thanks for an awesome plugin I've used a lot! Really helps my flow in Obsidian :)