### PR TITLE
Adapt to links in tables and bases

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -248,7 +248,7 @@ export default class JumpToLink extends Plugin {
     }
 
     handleHotkey(heldShiftKey: boolean, link: SourceLinkHint | LinkHintBase) {
-        if (link.linkText === undefined && link.linkElement) {
+        if ((link.linkText === undefined || link.linkText === '') && link.linkElement) {
             link.linkElement.click();
         } else if (link.type === 'internal') {
             const file = this.app.workspace.getActiveFile()

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -102,6 +102,7 @@ export function getPreviewLinkHints(previewViewEl: HTMLElement, letters: string 
 }
 
 export function checkIsPreviewElOnScreen(parent: HTMLElement, el: HTMLElement) {
+    el = el.closest('[data-view-type="table"], table') || el;
     return el.offsetTop < parent.scrollTop || el.offsetTop > parent.scrollTop + parent.offsetHeight
 }
 


### PR DESCRIPTION
- Links in bases have an empty `linkText`.
- Make links in bases and tables pass the `checkIsPreviewElOnScreen` test.