### PR TITLE
fix: support opening links in bases in new tab

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "mrj-jump-to-link",
   "name": "Jump to link",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "This plugin allows open a link in current document or regex based navigation in editor mode using hotkey",
   "isDesktopOnly": false,
   "author": "MrJackphil",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mrj-jump-to-link",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "This plugin allows open a link in current document using hotkey",
   "main": "main.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -249,7 +249,13 @@ export default class JumpToLink extends Plugin {
 
     handleHotkey(heldShiftKey: boolean, link: SourceLinkHint | LinkHintBase) {
         if ((link.linkText === undefined || link.linkText === '') && link.linkElement) {
-            link.linkElement.click();
+            const event = new MouseEvent("click", {
+                bubbles: true,
+                cancelable: true,
+                view: window,
+                metaKey: heldShiftKey,
+            });
+            link.linkElement.dispatchEvent(event);
         } else if (link.type === 'internal') {
             const file = this.app.workspace.getActiveFile()
             if (file) {


### PR DESCRIPTION
Simply running `.click()` on these links can't open them in a new tab. Use a mouse event to solve this.